### PR TITLE
Problem: passing transaction and accessor around is not trivial

### DIFF
--- a/src/tx.rs
+++ b/src/tx.rs
@@ -388,6 +388,15 @@ pub struct ResetTransaction<'env>(ReadTransaction<'env>);
 /// parameter, eg `&'x lmdb::ConstAccessor<'x>`.
 #[derive(Debug)]
 pub struct ConstAccessor<'txn>(&'txn ConstTransaction<'txn>);
+
+/// ConstAccessor implements Drop trait so that if it gets
+/// dropped, a new accessor can be safely obtained
+impl<'txn> Drop for ConstAccessor<'txn> {
+    fn drop(&mut self) {
+        self.0.has_yielded_accessor.set(false)
+    }
+}
+
 /// A read-write data accessor obtained from a `WriteTransaction`.
 ///
 /// All operations that can be performed on `ConstAccessor` can also be


### PR DESCRIPTION
It's (nearly?) impossible to use accessors in scenarios that
fall out of commonly suggested pattern of:

```rust
{
  let accessor = txn.access();

  // work with the database
}

txn.commit();
```

Particularly, if the transaction is done in a few places
across the codebase, passing accessor throughout poses
a challenge.

Solution: implement Drop trait for ConstAccessor so that if it
gets dropped, a new one can be easily obtained.

P.S. I might be missing something. Would my patch violate any of the guarantees? I am still new to Rust. It made my code work so far (I have a specific requirement of being able to pass the accessor around), but haven't done much research. The tests pass.