### PR TITLE
Ergonomics Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 target
 Cargo.lock
+.cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ wrapper around LMDB.
 liblmdb-sys = "0.2.1"
 bitflags = "0.7.0"
 libc = "0.2.14"
+supercow = "0.1.0"
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ wrapper around LMDB.
 
 [dependencies]
 liblmdb-sys = "0.2.2"
-bitflags = "0.7.0"
+bitflags = "0.8.0"
 libc = "0.2.14"
 supercow = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 repository = "https://github.com/AltSysrq/lmdb-zero"
 documentation = "https://docs.rs/lmdb-zero"
 keywords = ["lmdb", "zero-copy", "btree"]
+categories = ["database"]
 
 description = """
 An almost-safe, near-zero-cost, feature-complete, unabashedly non-abstract

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lmdb-zero"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["FullContact, Inc", "Jason Lingle"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ wrapper around LMDB.
 """
 
 [dependencies]
-liblmdb-sys = "0.2.1"
+liblmdb-sys = "0.2.2"
 bitflags = "0.7.0"
 libc = "0.2.14"
 supercow = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ is of course possible there are bugs in handling alignment here.
 
 ## Changelog
 
+**0.4.0**: Minor breaking changes. `ConstAccessor` and `WriteAccessor` can now
+  be dropped and re-obtained. Most types now support additional
+  ownership/borrowing modes, which allows for dynamic lifetime management and
+  other possibilities. Upgrade to `liblmdb-sys` 0.2.2 and `bitflags` 0.8.0.
+  Fixes to documentation.
+
 **0.3.1**: Metadata updates to reflect change of crate ownership. No software
   changes were made in this version.
 
@@ -56,6 +62,23 @@ is of course possible there are bugs in handling alignment here.
 **0.2.0**: Switch from `lmdb-sys` to newer `liblmdb-sys`.
 
 **0.1.0**: Initial release.
+
+### Breaking Changes in 0.4.0
+
+A number of functions which formerly took an `&SomeType` parameter now take an
+`Into<Supercow<SomeType>>`. For the vast majority of existing code, this has no
+effect, but it could cause issues if older code was relying on an implicit
+`Deref` call (for example, via `lazy_static!`) to produce the correct reference
+type. If this causes issues, explicitly writing the dereferencing is required.
+For example, if your code originally had `lmdb::Database::open(&ENV, ...)` where
+`ENV` was declared via `lazy_static!`, it would need to be changed to
+`lmdb::Database::open(&*ENV, ...)`.
+
+`ConstAccessor` and `WriteAccessor` must now be _strictly_ outlived by their
+transactions. No practical cases where this would be an issue are apparent, but
+if it comes up, code must be rearranged to ensure the accessor is dropped
+before the transaction. Note that now one can drop the accessor and later
+re-obtain it.
 
 ### Breaking Changes in 0.3.0
 

--- a/README.md
+++ b/README.md
@@ -4,20 +4,11 @@ lmdb-zero is a near-zero-cost wrapper around [LMDB](http://lmdb.tech/) designed
 to allow using the full range of features offered by LMDB while keeping it
 reasonably easy to write safe programs.
 
-[Documentation](https://docs.rs/lmdb-zero)
-
-## Why _another_ LMDB library?
-
-_There already exist the competing `lmdb` and `lmdb-rs` crates right now. Why
-write a third?_
-
-The main issue with the existing crates is that they try to abstract some
-properties of LMDB away, and as a result are not able to expose some of LMDB's
-functionality, and in some cases compromise safety.
-
-`lmdb-zero` is instead as much as possible a 1:1 mapping of the raw API, mainly
+`lmdb-zero` is as much as possible a 1:1 mapping of the raw API, mainly
 providing RAII constructs and integration into Rust's borrow checker to ensure
 safety.
+
+[Documentation](https://docs.rs/lmdb-zero)
 
 ## Features
 
@@ -37,14 +28,14 @@ safety.
 
 ## Status
 
-The API is complete but not necessarily completely stable; there may yet be
-unsound parts of the API or the implementations.
+The API is complete and reasonably stable and is believed to be sound insofar
+as Rust's unsafety rules are actually defined.
 
-This crate has not been tested on architectures with strong alignment
-constraints. While the conversion API checks for correct alignment by default,
-issues such as [#27060](https://github.com/rust-lang/rust/issues/27060) could
-come up, and it is of course possible there are bugs in handling alignment
-here.
+This crate has not been thoroughly tested on architectures with strong
+alignment constraints, though the tests pass on ARM7. While the conversion API
+checks for correct alignment by default, issues such as
+[#27060](https://github.com/rust-lang/rust/issues/27060) could come up, and it
+is of course possible there are bugs in handling alignment here.
 
 ## Changelog
 

--- a/src/dbi.rs
+++ b/src/dbi.rs
@@ -95,32 +95,6 @@ pub mod db {
             /// txn.commit().unwrap();
             /// # }
             /// ```
-            ///
-            /// ## Segmentation Faults
-            ///
-            /// Users on AMD64 with most GCC versions may encounter
-            /// segmentation faults when using this option in a release build
-            /// due to a bug in which the LMDB code that handles this option is
-            /// improperly vectorised. If you run into this issue, you can work
-            /// around it in a couple ways:
-            ///
-            /// - Use a different C compiler. This is the best option, as the
-            /// problem does not occur with Clang. For example, if you have
-            /// Clang 3.7 installed as `clang-3.7`, you can use it for
-            /// compiling C code by running, eg, `CC=clang-3.7 cargo build
-            /// --release`. Note that you need to first `cargo clean` for this
-            /// to take effect everywhere. If you are writing a library, keep
-            /// in mind that this means pushing this requirement up to your
-            /// client applications as well.
-            ///
-            /// - Adjust the build process to compile C code with `-O2` instead
-            /// of `-O3`.
-            ///
-            /// - Rework your code to not need this option.
-            ///
-            /// - If all your keys and data values have sizes which are a
-            /// multiple of 16, the problem may be masked. (This workaround has
-            /// not been tested.)
             const DUPSORT = ffi::MDB_DUPSORT,
             /// Keys are binary integers in native byte order, either
             /// `libc::c_uint` or `libc::size_t`, and will be sorted as such.

--- a/src/dbi.rs
+++ b/src/dbi.rs
@@ -664,6 +664,43 @@ impl<'a> Database<'a> {
         Ok(())
     }
 
+    /// Returns a reference to the `Environment` to which this `Database`
+    /// belongs.
+    ///
+    /// This can be used to elide needing to pass both an `&Environment` and an
+    /// `&Database` around, but is also useful for the use-case wherein the
+    /// `Database` owns the `Environment`.
+    ///
+    /// Because this may borrow an `Environment` owned by this `Database`, the
+    /// lifetime of the returned reference is dependent on self rather than
+    /// being `'env`. (In fact, `'env` is usually `'static` if the
+    /// `Environment` is owned by the `Database`, so returning `&'env Environment`
+    /// is impossible anyway.)
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # include!("src/example_helpers.rs");
+    /// # #[allow(unused_vars)]
+    /// # fn main() {
+    /// let env: lmdb::Environment = create_env();
+    /// // We only want one `Database`, so don't bother keeping both variables
+    /// // around and instead let the `Database` own the `Environment`.
+    /// let db = lmdb::Database::open(
+    ///   env, None, &lmdb::DatabaseOptions::defaults()).unwrap();
+    ///
+    /// // `env` has been consumed, but we can still do useful things by
+    /// // getting a reference to the inner value.
+    /// let txn = lmdb::ReadTransaction::new(db.env()).unwrap();
+    ///
+    /// // Do stuff with `txn`, etc.
+    /// # }
+    /// ```
+    #[inline]
+    pub fn env(&self) -> &Environment {
+        &*self.db.env
+    }
+
     /// Checks that `other_env` is the same as the environment on this
     /// `Database`.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,7 @@
 
 extern crate liblmdb_sys as ffi;
 extern crate libc;
+extern crate supercow;
 #[macro_use] extern crate bitflags;
 
 use std::ffi::CStr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright 2016 FullContact, Inc
+// Copyright 2017 Jason Lingle
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -41,7 +42,8 @@
 //!     // Write some data in a transaction
 //!     let txn = lmdb::WriteTransaction::new(&env).unwrap();
 //!     // An accessor is used to control memory access.
-//!     // NB You can only get the accessor from the transaction once.
+//!     // NB You can only have one live accessor from a particular transaction
+//!     // at a time. Violating this results in a panic at runtime.
 //!     {
 //!       let mut access = txn.access();
 //!       access.put(&db, "Germany", "Berlin", lmdb::put::Flags::empty()).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@
 //! If you want to define your own types to store in the database, see the
 //! `lmdb_zero::traits` submodule.
 //!
-//! # Lifetimes
+//! # Lifetimes and Ownership
 //!
 //! Lmdb-zero heavily uses lifetime parameters to allow user code to safely
 //! retain handles into LMDB without extra runtime overhead.
@@ -129,6 +129,45 @@
 //! as struct members. The documentation for each type with lifetime parameters
 //! therefore includes a short discussion of how the lifetimes are intended to
 //! interact and how best to work with them.
+//!
+//! It is also possible to opt-out of compile-time lifetime tracking and
+//! instead use `Arc` or `Rc` around various handles. In this case, all the
+//! lifetime parameters simply become `'static`. See the next section for
+//! details.
+//!
+//! ## Ownership Modes
+//!
+//! As of version 0.4.0, most APIs which construct a value which holds on to
+//! some "parent" value (e.g., creating a `Database` within an `Environment`)
+//! accept anything that can be converted into a [`Supercow`](https://docs.rs/supercow/0.1.0/supercow/).
+//! Deep understanding of `Supercow` itself is not required to use `lmdb-zero`.
+//! The only thing you need to know is that an `Into<Supercow<T>>` means that
+//! you can pass in one of three classes of arguments:
+//!
+//! - `&T`. This is "borrowed mode". The majority of the documentation in this
+//! crate uses borrowed mode. This is zero-overhead and is statically
+//! verifiable (i.e., all usage is checked at compile-time), so it is
+//! recommended that borrowed mode be used whenever reasonably possible. This
+//! mode causes the "child" value to hold a normal reference to the parent,
+//! which means that lifetimes must be tracked in the lifetime parameters. But
+//! because of this, this mode can be inflexible; for example, you cannot use
+//! safe Rust to create a `struct` holding both an `Environment` and its
+//! `Database`s using borrowed mode.
+//!
+//! - `Arc<T>`. This is "shared mode". For `NonSyncSupercow`, `Rc<T>` may also
+//! be used. The child will hold the `Arc` or `Rc`, thus ensuring the parent
+//! lives at least as long as the child. Because of this, the related lifetime
+//! parameters can simply be written as `'static`. It also means that
+//! `Arc`/`Rc` references to the child and parent can be placed together in the
+//! same struct with safe Rust. This comes at a cost: Constructing values in
+//! shared mode incurs allocation; additionally, the ability to statically
+//! verify the lifetime of the parent values is lost.
+//!
+//! - `T`. This is "owned mode". The parent is moved into the child value and
+//! owned by the child from thereon. This is most useful when you only ever
+//! want one child and don't care about retaining ownership of the parent. As
+//! with shared mode, it also allows simply using `'static` as the relevant
+//! lifetime parameters.
 //!
 //! # Major Differences from the LMDB C API
 //!
@@ -166,6 +205,10 @@
 //!   values are slightly larger and some function calls have an extra (very
 //!   predictable) branch if the optimiser does not optimise the branch away
 //!   entirely.
+//!
+//! - Using ownership modes other than borrowed (i.e., mundane references)
+//!   incurs extra allocations in addition to the overhead of inherent in that
+//!   ownership mode.
 //!
 //! # Using Zero-Copy
 //!

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -259,10 +259,11 @@ pub trait FromReservedLmdbBytes {
 /// Implementing this trait provides blanket implementations of
 /// `AsLmdbBytes`, `FromLmdbBytes`, and `FromReservedLmdbBytes`.
 ///
-/// All integer and floating-point types have this trait, as well as
-/// fixed-width arrays of up to 32 `LmdbRaw` types, and the empty tuple.
-/// (One cannot use `LmdbRaw` with tuples in general, as the physical
-/// layout of tuples is not currently defined.)
+/// See also [`LmdbRawIfUnaligned`](trait.LmdbRawIfUnaligned.html) for types
+/// that become `LmdbRaw` when wrapped with
+/// [`Unaligned`](../struct.Unaligned.html). In particular, all integer and
+/// floating-point types are `LmdbRawIfUnaligned`, except for `u8` and `i8`
+/// which are also `LmdbRaw`.
 ///
 /// ## Alignment
 ///
@@ -382,8 +383,10 @@ pub unsafe trait LmdbRaw : Copy + Sized {
 /// client code to wrap the type in `Unaligned` to explicitly handle possible
 /// misalignment.
 ///
+/// All integer and floating-point types have this trait.
+///
 /// Note that `LmdbRawIfUnaligned` is not blanket-implemented for fixed-size
-/// arrays, because currently doing so would preclude a blanke implementation
+/// arrays, because currently doing so would preclude a blanket implementation
 /// of `LmdbRaw` for fixed-size arrays. Since the latter is generally more
 /// useful and is more consistent since variable-length slices can only
 /// usefully interact with `LmdbRaw`, that approach was chosen.

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -292,6 +292,11 @@ impl TxHandle {
 /// underlying database, but rather exclusivity for enforcement of child
 /// transaction semantics.
 ///
+/// ## Ownership
+///
+/// Transactions support all three ownership modes (but owned mode is not
+/// useful). See `ReadTransaction` and `WriteTransaction` for details.
+///
 /// ## Lifetime
 ///
 /// A `ConstTransaction` must be strictly outlived by its `Environment`.
@@ -327,6 +332,31 @@ pub struct ConstTransaction<'env> {
 /// `ReadTransaction` can additionally operate on cursors with a lifetime
 /// scoped to the environment instead of the transaction.
 ///
+/// ## Ownership
+///
+/// `ReadTransaction`s can be created with all three ownership modes (but owned
+/// mode is not useful).
+///
+/// ### Example — Shared mode
+///
+/// ```
+/// # include!("src/example_helpers.rs");
+/// use std::sync::Arc;
+///
+/// # fn main() {
+/// let env = Arc::new(create_env());
+/// let db = Arc::new(lmdb::Database::open(
+///   env.clone(), None, &lmdb::DatabaseOptions::defaults()).unwrap());
+///
+/// // Type and lifetime annotated explicitly for clarity
+/// let txn: lmdb::ReadTransaction<'static> = lmdb::ReadTransaction::new(
+///   env.clone()).unwrap();
+///
+/// // Do stuff with `txn`...
+/// # drop(txn); drop(db);
+/// # }
+/// ```
+///
 /// ## Lifetime
 ///
 /// All notes for `ConstTransaction` apply.
@@ -337,6 +367,33 @@ pub struct ReadTransaction<'env>(ConstTransaction<'env>);
 ///
 /// In addition to all operations valid on `ConstTransaction`, it is also
 /// possible to perform writes to the underlying databases.
+///
+///
+/// ## Ownership
+///
+/// `WriteTransaction`s can be created with all three ownership modes (but
+/// owned mode is not useful).
+///
+/// ### Example — Shared mode
+///
+/// ```
+/// # include!("src/example_helpers.rs");
+/// use std::sync::Arc;
+///
+/// # fn main() {
+/// let env = Arc::new(create_env());
+/// let db = Arc::new(lmdb::Database::open(
+///   env.clone(), None, &lmdb::DatabaseOptions::defaults()).unwrap());
+///
+/// // Type and lifetime annotated explicitly for clarity
+/// let txn: lmdb::WriteTransaction<'static> = lmdb::WriteTransaction::new(
+///   env.clone()).unwrap();
+///
+/// // Do stuff with `txn`...
+///
+/// txn.commit().unwrap();
+/// # }
+/// ```
 ///
 /// ## Lifetime
 ///

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -770,7 +770,6 @@ impl<'env> ResetTransaction<'env> {
     /// reading.
     pub fn renew(self) -> Result<ReadTransaction<'env>> {
         unsafe { lmdb_call!(ffi::mdb_txn_renew((self.0).0.tx.0)); }
-        self.0.has_yielded_accessor.set(false);
         Ok(self.0)
     }
 }
@@ -880,10 +879,6 @@ impl<'env> WriteTransaction<'env> {
     /// ```
     pub fn child_tx<'a>(&'a mut self) -> Result<WriteTransaction<'a>>
     where 'env: 'a {
-        // Allow the caller to later retrieve a new accessor, since the borrow
-        // rules ensure that they've destroyed the old one.
-        self.has_yielded_accessor.set(false);
-
         let env = Supercow::share(&mut self.0.env);
         Ok(WriteTransaction(try!(ConstTransaction::new(
             env, Some(&mut*self), 0))))


### PR DESCRIPTION
After a bit of a hiatus, I've finally gotten around to finishing some major ergonomics improvements I'd been planning for quite some time.

The largest change here is that the API now supports optionally using `Arc`s or `Rc`s to manage lifetimes of the various components instead of needing to use simple references. This means it is finally possible to pass a `Database` and `Environment` around together, or a transaction and its cursors around together, without needing to resort to unsafety or using a continuation-passing style to keep everything on the stack. There are plenty of examples in the commits of how this can be used. Hopefully this addresses the difficulties brought up in https://github.com/AltSysrq/lmdb-zero/issues/3 and https://github.com/AltSysrq/lmdb-zero/issues/6.

I've rolled https://github.com/AltSysrq/lmdb-zero/pull/5 into this branch as well. Accessors may now be dropped and then reacquired.

Among documentation improvements, https://github.com/AltSysrq/lmdb-zero/issues/4 is also addressed.

All code I know of and have access to using vanilla 0.3.x compiles and runs without changes against this branch, so while breakage is theoretically possible, it will likely be minor at worst.

Since this is a fairly sweeping change to the API and uses my admittedly exotic `supercow` crate to accomplish support for `Arc`s, etc, I'm putting this on a PR for now in case anyone has any concerns to voice. If there are no objections, this will be published as version 0.4.0 next weekend.